### PR TITLE
Add gem for dependency of nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ git_source(:github) do |repo_name|
 end
 
 gem 'simple_form'
+# Dependency of nokogiri for heroku
+gem 'mini_portile2', '~> 2.3.0'
 # Use dotenv for reading env-variables
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 # Use devise for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     nenv (0.3.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     nenv (0.3.0)
@@ -288,6 +289,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   less-rails
   listen (>= 3.0.5, < 3.2)
+  mini_portile2 (~> 2.3.0)
   pg (>= 0.18, < 2.0)
   puma (~> 3.7)
   rails (~> 5.1.6)


### PR DESCRIPTION
やりたかったこと
---

- Herokuへのデプロイを成功させるための修正


やったこと
----

- Gemfileに必要だと思われるジェムを追加



動作確認方法
---

- [ ] Herokuにデプロイする


その他
---

HerokuのBuild.log
```
       Downloading nokogiri-1.8.2 revealed dependencies not in the API or the lockfile

       (mini_portile2 (~> 2.3.0)).

       Either installing with `--full-index` or running `bundle update nokogiri` should

       fix the problem.

 !

 !     Failed to install gems via Bundler.

 !

 !     Push rejected, failed to compile Ruby app.

 !     Push failed
```